### PR TITLE
Memlet with Evictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "precommit": "npm run prepare",
     "prepare": "rimraf lib && rollup -c && tsc",
     "test": "mocha -r sucrase/register test/**/*.test.ts",
-    "dev": "mocha -r sucrase/register test/**/*.test.ts --watch --watch-files [src/**/*, test/**/*]"
+    "dev": "mocha -r sucrase/register test/**/*.test.ts --watch --watch-files 'src/**/*, test/**/*'"
   },
   "hooks": {
     "pre-commit": "npm test"

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -1,0 +1,61 @@
+import { File } from './types'
+
+export function makeFileQueue() {
+  const filesOrderedByDate: FileQueue = []
+
+  return {
+    queue: function (file: File) {
+      const fileEntry: FileQueueEntry = {
+        filename: file.filename,
+        timestamp: file.lastTouchedTimestamp
+      }
+
+      filesOrderedByDate.push(fileEntry)
+    },
+    dequeue: function () {
+      return filesOrderedByDate.shift()
+    },
+    requeue: function (file: File) {
+      const index = binarySearch(filesOrderedByDate, fileEntry => {
+        return file.filename === fileEntry.filename
+          ? 0
+          : file.lastTouchedTimestamp - fileEntry.timestamp ||
+              // Fallback to lexigraphical comparison (if timestamps match)
+              (file.filename > fileEntry.filename ? 1 : -1)
+      })
+
+      if (index >= 0) {
+        filesOrderedByDate.splice(index, 1)
+      }
+
+      this.queue(file)
+    },
+    list: function () {
+      return filesOrderedByDate
+    }
+  }
+}
+
+function binarySearch<T>(ar: T[], compareFn: (el: T) => number) {
+  var m = 0
+  var n = ar.length - 1
+  while (m <= n) {
+    var k = (n + m) >> 1
+    var cmp = compareFn(ar[k])
+    if (cmp > 0) {
+      m = k + 1
+    } else if (cmp < 0) {
+      n = k - 1
+    } else {
+      return k
+    }
+  }
+  return -m - 1
+}
+
+export type FileQueue = FileQueueEntry[]
+
+export interface FileQueueEntry {
+  filename: string
+  timestamp: number
+}

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -5,21 +5,16 @@ export function makeFileQueue() {
 
   return {
     queue: function (file: File) {
-      const fileEntry: FileQueueEntry = {
-        filename: file.filename,
-        timestamp: file.lastTouchedTimestamp
-      }
-
-      filesOrderedByDate.push(fileEntry)
+      filesOrderedByDate.push(file)
     },
     dequeue: function () {
       return filesOrderedByDate.shift()
     },
     requeue: function (file: File) {
       const index = binarySearch(filesOrderedByDate, fileEntry => {
-        return file.filename === fileEntry.filename
+        return file === fileEntry
           ? 0
-          : file.lastTouchedTimestamp - fileEntry.timestamp ||
+          : file.lastTouchedTimestamp - fileEntry.lastTouchedTimestamp ||
               // Fallback to lexigraphical comparison (if timestamps match)
               (file.filename > fileEntry.filename ? 1 : -1)
       })
@@ -53,9 +48,4 @@ function binarySearch<T>(ar: T[], compareFn: (el: T) => number) {
   return -m - 1
 }
 
-export type FileQueue = FileQueueEntry[]
-
-export interface FileQueueEntry {
-  filename: string
-  timestamp: number
-}
+export type FileQueue = File[]

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -11,24 +11,30 @@ export function makeFileQueue() {
       return filesOrderedByDate.shift()
     },
     requeue: function (file: File) {
-      const index = binarySearch(filesOrderedByDate, fileEntry => {
-        return file === fileEntry
-          ? 0
-          : file.lastTouchedTimestamp - fileEntry.lastTouchedTimestamp ||
-              // Fallback to lexigraphical comparison (if timestamps match)
-              (file.filename > fileEntry.filename ? 1 : -1)
-      })
+      this.remove(file)
+      this.queue(file)
+    },
+    remove: function (file: File) {
+      const index = indexOfFileInQueue(filesOrderedByDate, file)
 
       if (index >= 0) {
         filesOrderedByDate.splice(index, 1)
       }
-
-      this.queue(file)
     },
     list: function () {
       return filesOrderedByDate
     }
   }
+}
+
+function indexOfFileInQueue(fileQueue: FileQueue, file: File) {
+  return binarySearch(fileQueue, fileInQueue => {
+    return file === fileInQueue
+      ? 0
+      : file.lastTouchedTimestamp - fileInQueue.lastTouchedTimestamp ||
+          // Fallback to lexigraphical comparison (if timestamps match)
+          (file.filename > fileInQueue.filename ? 1 : -1)
+  })
 }
 
 function binarySearch<T>(ar: T[], compareFn: (el: T) => number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,8 @@ export function makeMemlet(
       adjustMemoryUsage(-file.size)
       delete store.files[filename]
     }
+
+    return file
   }
 
   const adjustMemoryUsage = (bytes?: number) => {
@@ -95,7 +97,12 @@ export function makeMemlet(
        * (because disklet delete might succeed in delete, but fail on
        * something else).
        */
-      deleteStoreFile(path)
+      const file = deleteStoreFile(path)
+
+      if (file) {
+        fileQueue.remove(file)
+      }
+
       await disklet.delete(path)
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,28 @@
 import { Disklet } from 'disklet'
-import { Memlet, MemletStore, File } from './types'
+
+import { Memlet, MemletStore, File, MemletConfig } from './types'
+import { makeFileQueue } from './file-queue'
 
 export * from './types'
 
-export function makeMemlet(disklet: Disklet): Memlet {
+const defaultConfig: MemletConfig = {
+  maxMemoryUsage: 0
+}
+
+export function makeMemlet(
+  disklet: Disklet,
+  configOptions: Partial<MemletConfig> = {}
+): Memlet {
   // Private properties
+
+  const config = { ...defaultConfig, ...configOptions }
 
   const store: MemletStore = {
     memoryUsage: 0,
     files: {}
   }
+
+  const fileQueue = makeFileQueue()
 
   // Private methods
 
@@ -25,43 +38,76 @@ export function makeMemlet(disklet: Disklet): Memlet {
       lastTouchedTimestamp
     }
 
-    // Calculate the difference in memory useage if there is an existing file
+    if (extingFile) {
+      // Update file's position in the file queue
+      fileQueue.requeue(newFile)
+    } else {
+      // Add file to the file queue
+      fileQueue.queue(newFile)
+    }
+
+    // Calculate the difference in memory usage if there is an existing file
     const memoryUsageDiff = extingFile
       ? newFile.size - extingFile.size
       : newFile.size
 
     // Update memoryUsage using add method
-    addToMemoryUsage(memoryUsageDiff)
+    adjustMemoryUsage(memoryUsageDiff)
 
     // Update file in store
     store.files[key] = newFile
   }
 
-  const addToMemoryUsage = (bytes: number) => {
-    store.memoryUsage += bytes
+  // Used to add undefined type checking to file retrieval
+  const getStoreFile = (filename: string): File | undefined => {
+    return store.files[filename]
+  }
+
+  const deleteStoreFile = (filename: string) => {
+    const file = getStoreFile(filename)
+
+    if (file) {
+      adjustMemoryUsage(-file.size)
+      delete store.files[filename]
+    }
+  }
+
+  const adjustMemoryUsage = (bytes?: number) => {
+    if (bytes) {
+      store.memoryUsage += bytes
+    }
+
+    // Remove files if memory usage exceeds maxMemoryUsage
+    if (store.memoryUsage > config.maxMemoryUsage) {
+      const fileEntry = fileQueue.dequeue()
+      if (fileEntry) {
+        // Deleting file from store will invoke adjustMemoryUsage again
+        deleteStoreFile(fileEntry.filename)
+      }
+    }
   }
 
   return {
     // Removes an object at a given path
-    delete: async (path: string) => {
+    delete: async function (path: string) {
       /**
        * No soft-delete: delete from memlet first then delete from disklet
        * (because disklet delete might succeed in delete, but fail on
        * something else).
        */
-      delete store.files[path]
+      deleteStoreFile(path)
       await disklet.delete(path)
     },
 
     // Lists objects from a given path
-    list: async (path?: string) => {
+    list: async function (path?: string) {
       // Direct pass-through to disklet
       return await disklet.list(path)
     },
 
     // Get an object at given path
-    getJson: async (filename: string) => {
-      const file = store.files[filename]
+    getJson: async function (filename: string) {
+      const file = getStoreFile(filename)
 
       if (file) {
         // Return file found in memory store
@@ -78,7 +124,7 @@ export function makeMemlet(disklet: Disklet): Memlet {
     },
 
     // Set an object at a given path
-    setJson: async (filename: string, data: any) => {
+    setJson: async function (filename: string, data: any) {
       /**
        * Write-through policy: write to disklet first then put it in the cache.
        */
@@ -90,7 +136,7 @@ export function makeMemlet(disklet: Disklet): Memlet {
     },
 
     // Introspective methods
-    _getStore: () => {
+    _getStore: function () {
       return store
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,3 @@ export interface File {
   lastTouchedTimestamp: number
 }
 
-// export type FileIndex = FileIndexEntry[]
-
-// export interface FileIndexEntry {
-//   filename: string
-//   timestamp: number
-// }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,11 @@ export interface Memlet {
 
 export interface MemletStore {
   memoryUsage: number
-  // maxMemoryUseage: number
   files: FileMap
-  // filesOrderedByDate: FileIndex
+}
+
+export interface MemletConfig {
+  maxMemoryUsage: number
 }
 
 export interface FileMap {

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -3,6 +3,7 @@ import { makeMemoryDisklet } from 'disklet'
 import { describe, it } from 'mocha'
 
 import { makeMemlet, Memlet } from '../src/index'
+import { delay } from './utils'
 
 export async function createObjects(memlet: Memlet) {
   const fileA = { content: 'file content' }
@@ -45,6 +46,7 @@ describe('memlet with evictions', async () => {
     })
 
     await memlet.setJson('File-A', fileA)
+    await delay(10)
     await memlet.setJson('File-B', fileB)
 
     const store = memlet._getStore()

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai'
+import { makeMemoryDisklet } from 'disklet'
+import { describe, it } from 'mocha'
+
+import { makeMemlet, Memlet } from '../src/index'
+
+export async function createObjects(memlet: Memlet) {
+  const fileA = { content: 'file content' }
+  const folderA = { content: 'folder content' }
+  const fileB = { content: 'subfolder content' }
+
+  memlet.setJson('File-A', fileA)
+  memlet.setJson('Folder-A', folderA)
+  memlet.setJson('Folder-A/File-B', fileB)
+
+  return { fileA, folderA, fileB }
+}
+
+describe('memlet with evictions', async () => {
+  it('can add files within maxMemoryUsage', async () => {
+    const fileA = { content: 'some content' }
+    const fileASize = JSON.stringify(fileA).length
+
+    const disklet = makeMemoryDisklet()
+    const memlet = makeMemlet(disklet, { maxMemoryUsage: fileASize })
+
+    await memlet.setJson('File-A', fileA)
+
+    const store = memlet._getStore()
+
+    // Check files
+    expect(Object.keys(store.files)).deep.equals(['File-A'])
+    // Check memoryUsage
+    expect(store.memoryUsage).to.equal(fileASize)
+  })
+
+  it('will remove old files when exceeding maxMemoryUsage', async () => {
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some other content' }
+    const fileBSize = JSON.stringify(fileB).length
+
+    const disklet = makeMemoryDisklet()
+    const memlet = makeMemlet(disklet, {
+      maxMemoryUsage: fileBSize
+    })
+
+    await memlet.setJson('File-A', fileA)
+    await memlet.setJson('File-B', fileB)
+
+    const store = memlet._getStore()
+
+    // Check files
+    expect(Object.keys(store.files)).deep.equals(['File-B'])
+    // Check memoryUsage
+    expect(store.memoryUsage).to.equal(fileBSize)
+  })
+})

--- a/test/file-queue.test.ts
+++ b/test/file-queue.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { makeFileQueue } from '../src/file-queue'
+import { File } from '../src'
+
+describe('FileQueue', async () => {
+  const fileA: File = {
+    filename: 'file-A',
+    data: 'content',
+    size: 123,
+    lastTouchedTimestamp: Date.now()
+  }
+  const fileB: File = {
+    filename: 'file-B',
+    data: 'content',
+    size: 123,
+    lastTouchedTimestamp: Date.now() + 1000
+  }
+  const fileC: File = {
+    filename: 'file-C',
+    data: 'content',
+    size: 123,
+    lastTouchedTimestamp: Date.now() + 2000
+  }
+
+  it('can queue files', async () => {
+    const fileQueue = makeFileQueue()
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+
+    expect(filenames).deep.equals(['file-A', 'file-B', 'file-C'])
+  })
+
+  it('can dequeue files', async () => {
+    const fileQueue = makeFileQueue()
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    const removedFile = fileQueue.dequeue()
+
+    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+
+    expect(filenames).deep.equals(['file-B', 'file-C'])
+    expect(removedFile?.filename).equals('file-A')
+  })
+
+  it('can requeue files', async () => {
+    const fileQueue = makeFileQueue()
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    fileQueue.requeue(fileA)
+
+    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+
+    expect(filenames).deep.equals(['file-B', 'file-C', 'file-A'])
+  })
+})

--- a/test/file-queue.test.ts
+++ b/test/file-queue.test.ts
@@ -64,4 +64,18 @@ describe('FileQueue', async () => {
 
     expect(filenames).deep.equals(['file-B', 'file-C', 'file-A'])
   })
+
+  it('can remove files', async () => {
+    const fileQueue = makeFileQueue()
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    fileQueue.remove(fileB)
+
+    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+
+    expect(filenames).deep.equals(['file-A', 'file-C'])
+  })
 })

--- a/test/file-queue.test.ts
+++ b/test/file-queue.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha'
 
 import { makeFileQueue } from '../src/file-queue'
 import { File } from '../src'
+import { delay } from './utils'
 
 describe('FileQueue', async () => {
   const fileA: File = {
@@ -15,13 +16,13 @@ describe('FileQueue', async () => {
     filename: 'file-B',
     data: 'content',
     size: 123,
-    lastTouchedTimestamp: Date.now() + 1000
+    lastTouchedTimestamp: Date.now() + 1
   }
   const fileC: File = {
     filename: 'file-C',
     data: 'content',
     size: 123,
-    lastTouchedTimestamp: Date.now() + 2000
+    lastTouchedTimestamp: Date.now() + 2
   }
 
   it('can queue files', async () => {
@@ -57,6 +58,8 @@ describe('FileQueue', async () => {
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
     fileQueue.queue(fileC)
+
+    await delay(10)
 
     fileQueue.requeue(fileA)
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,5 @@
+export const delay = (ms: number) => {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}


### PR DESCRIPTION
This change includes a file queue interface to manage a file queue ordered by timestamps to be used to evict files from the store when exceeding memory usage limits in a `Memlet` object.