### PR TITLE
Unit tests

### DIFF
--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -1,9 +1,9 @@
 import { File } from './types'
 
-export function makeFileQueue() {
+export function makeFileQueue(): FileQueue {
   const files: File[] = []
 
-  const fileQueue = {
+  const fileQueue: FileQueue = {
     /**
      * Inserts a file to the end of the queue with guaranteed ordering.
      * Files are ordered by lastTouchedTimestamp and then lexigraphical order
@@ -90,4 +90,12 @@ function indexOfFileInQueue(files: File[], file: File) {
 
   // Return -1 when file cannot be found.
   return -1
+}
+
+export interface FileQueue {
+  queue: (file: File) => void
+  dequeue: () => File | undefined
+  requeue: (file: File) => void
+  remove: (file: File) => void
+  list: () => File[]
 }

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -15,7 +15,7 @@ export function makeFileQueue() {
       let endFile = files[endFileIndex]
 
       while (
-        endFileIndex > 0 &&
+        endFileIndex >= 0 &&
         file.lastTouchedTimestamp <= endFile.lastTouchedTimestamp &&
         file.filename < endFile.filename
       ) {

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -12,15 +12,17 @@ export function makeFileQueue(): FileQueue {
      */
     queue: (file: File) => {
       let endFileIndex = files.length - 1
-      let endFile = files[endFileIndex]
 
-      while (
-        endFileIndex >= 0 &&
-        (file.lastTouchedTimestamp < endFile.lastTouchedTimestamp ||
+      for (; endFileIndex >= 0; --endFileIndex) {
+        const endFile = files[endFileIndex]
+
+        if (
+          file.lastTouchedTimestamp > endFile.lastTouchedTimestamp ||
           (file.lastTouchedTimestamp === endFile.lastTouchedTimestamp &&
-            file.filename < endFile.filename))
-      ) {
-        endFile = files[--endFileIndex]
+            file.filename > endFile.filename)
+        ) {
+          break
+        }
       }
 
       files.splice(endFileIndex + 1, 0, file)

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -1,66 +1,68 @@
 import { File } from './types'
 
 export function makeFileQueue() {
-  const fileQueue: File[] = []
+  const files: File[] = []
 
-  return {
+  const fileQueue = {
     /**
      * Inserts a file to the end of the queue with guaranteed ordering.
      * Files are ordered by lastTouchedTimestamp and then lexigraphical order
      * on filename.
      * @param file The file to insert into queue.
      */
-    queue: function (file: File) {
-      let endFileIndex = fileQueue.length - 1
-      let endFile = fileQueue[endFileIndex]
+    queue: (file: File) => {
+      let endFileIndex = files.length - 1
+      let endFile = files[endFileIndex]
 
       while (
         endFileIndex > 0 &&
         file.lastTouchedTimestamp <= endFile.lastTouchedTimestamp &&
         file.filename < endFile.filename
       ) {
-        endFile = fileQueue[--endFileIndex]
+        endFile = files[--endFileIndex]
       }
 
-      fileQueue.splice(endFileIndex + 1, 0, file)
+      files.splice(endFileIndex + 1, 0, file)
     },
-    dequeue: function () {
-      return fileQueue.shift()
+    dequeue: () => {
+      return files.shift()
     },
-    requeue: function (file: File) {
-      this.remove(file)
+    requeue: (file: File) => {
+      fileQueue.remove(file)
       file.lastTouchedTimestamp = Date.now()
-      this.queue(file)
+      fileQueue.queue(file)
     },
-    remove: function (file: File) {
-      const index = indexOfFileInQueue(fileQueue, file)
+    remove: (file: File) => {
+      const index = indexOfFileInQueue(files, file)
 
       if (index >= 0) {
-        fileQueue.splice(index, 1)
+        files.splice(index, 1)
       }
     },
-    list: function () {
-      return fileQueue
+    list: () => {
+      return files
     }
   }
+
+  return fileQueue
 }
 
 /**
  * Uses binary search to find the index of a given file in a given fileQueue.
  *
- * @param fileQueue Array of File objects sorted by lastTouchTimestamp
+ * @param files Array of sorted File objects
  * @param file The File object for which to search.
  */
-function indexOfFileInQueue(fileQueue: File[], file: File) {
+function indexOfFileInQueue(files: File[], file: File) {
   let l = 0
-  let r = fileQueue.length - 1
+  let r = files.length - 1
 
   while (l <= r) {
     // Use bit shift over division to avoid floats
     let index = (l + r) >> 1
 
     // File in queue to compare
-    const fileInQueue = fileQueue[index]
+    const fileInQueue = files[index]
 
     // Direction to continue binary search. Zero is a match.
     // Negative is to search lower and positive is to search higher.

--- a/src/file-queue.ts
+++ b/src/file-queue.ts
@@ -16,8 +16,9 @@ export function makeFileQueue() {
 
       while (
         endFileIndex >= 0 &&
-        file.lastTouchedTimestamp <= endFile.lastTouchedTimestamp &&
-        file.filename < endFile.filename
+        (file.lastTouchedTimestamp < endFile.lastTouchedTimestamp ||
+          (file.lastTouchedTimestamp === endFile.lastTouchedTimestamp &&
+            file.filename < endFile.filename))
       ) {
         endFile = files[--endFileIndex]
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { makeFileQueue } from './file-queue'
 export * from './types'
 
 const defaultConfig: MemletConfig = {
-  maxMemoryUsage: 0
+  maxMemoryUsage: Infinity
 }
 
 export function makeMemlet(
@@ -87,7 +87,7 @@ export function makeMemlet(
     }
 
     // Remove files if memory usage exceeds maxMemoryUsage
-    if (config.maxMemoryUsage && store.memoryUsage > config.maxMemoryUsage) {
+    if (store.memoryUsage > config.maxMemoryUsage) {
       const fileEntry = fileQueue.dequeue()
       if (fileEntry) {
         // Deleting file from store will invoke adjustMemoryUsage again

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export function makeMemlet(
     }
 
     // Remove files if memory usage exceeds maxMemoryUsage
-    if (store.memoryUsage > config.maxMemoryUsage) {
+    if (config.maxMemoryUsage && store.memoryUsage > config.maxMemoryUsage) {
       const fileEntry = fileQueue.dequeue()
       if (fileEntry) {
         // Deleting file from store will invoke adjustMemoryUsage again

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,8 @@ export function makeMemlet(
       const file = getStoreFile(filename)
 
       if (file) {
+        // Update file in store to update it's timestamp
+        updateStoreFile(file.filename, file.data, file.size)
         // Return file found in memory store
         return file.data
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function makeMemlet(
   const updateStoreFile = (key: string, data: any, size: number) => {
     const lastTouchedTimestamp = Date.now()
 
-    const extingFile = store.files[key]
+    const existingFile = store.files[key]
 
     const newFile: File = {
       size,
@@ -38,7 +38,7 @@ export function makeMemlet(
       lastTouchedTimestamp
     }
 
-    if (extingFile) {
+    if (existingFile) {
       // Update file's position in the file queue
       fileQueue.requeue(newFile)
     } else {
@@ -47,8 +47,8 @@ export function makeMemlet(
     }
 
     // Calculate the difference in memory usage if there is an existing file
-    const memoryUsageDiff = extingFile
-      ? newFile.size - extingFile.size
+    const memoryUsageDiff = existingFile
+      ? newFile.size - existingFile.size
       : newFile.size
 
     // Update memoryUsage using add method

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ export function makeMemlet(
     }
   }
 
-  return {
+  const memlet = {
     // Removes an object at a given path
-    delete: async function (path: string) {
+    delete: async (path: string) => {
       /**
        * No soft-delete: delete from memlet first then delete from disklet
        * (because disklet delete might succeed in delete, but fail on
@@ -107,13 +107,13 @@ export function makeMemlet(
     },
 
     // Lists objects from a given path
-    list: async function (path?: string) {
+    list: async (path?: string) => {
       // Direct pass-through to disklet
       return await disklet.list(path)
     },
 
     // Get an object at given path
-    getJson: async function (filename: string) {
+    getJson: async (filename: string) => {
       const file = getStoreFile(filename)
 
       if (file) {
@@ -131,7 +131,7 @@ export function makeMemlet(
     },
 
     // Set an object at a given path
-    setJson: async function (filename: string, data: any) {
+    setJson: async (filename: string, data: any) => {
       /**
        * Write-through policy: write to disklet first then put it in the cache.
        */
@@ -143,8 +143,10 @@ export function makeMemlet(
     },
 
     // Introspective methods
-    _getStore: function () {
+    _getStore: () => {
       return store
     }
   }
+
+  return memlet
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export function makeMemlet(
 ): Memlet {
   // Private properties
 
+  // Divide given maxMemoryUsage config parameter to respresent char-length
+  if (configOptions.maxMemoryUsage) {
+    configOptions.maxMemoryUsage = configOptions.maxMemoryUsage / 2
+  }
+
   const config = { ...defaultConfig, ...configOptions }
 
   const store: MemletStore = {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -16,7 +16,7 @@ export async function createObjects(memlet: Memlet) {
   return { fileA, folderA, fileB }
 }
 
-describe('memlet', async () => {
+describe('Memlet', async () => {
   const disklet = makeMemoryDisklet()
   const memlet = makeMemlet(disklet)
 

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -5,18 +5,6 @@ import { describe, it } from 'mocha'
 import { makeMemlet, Memlet } from '../src/index'
 import { delay } from './utils'
 
-export async function createObjects(memlet: Memlet) {
-  const fileA = { content: 'file content' }
-  const folderA = { content: 'folder content' }
-  const fileB = { content: 'subfolder content' }
-
-  memlet.setJson('File-A', fileA)
-  memlet.setJson('Folder-A', folderA)
-  memlet.setJson('Folder-A/File-B', fileB)
-
-  return { fileA, folderA, fileB }
-}
-
 describe('memlet with evictions', async () => {
   it('can add files within maxMemoryUsage', async () => {
     const fileA = { content: 'some content' }

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { makeMemoryDisklet } from 'disklet'
 import { describe, it } from 'mocha'
 
-import { makeMemlet, Memlet } from '../src/index'
+import { makeMemlet } from '../src/index'
 import { delay } from './utils'
 
 describe('Memlet with evictions', async () => {
@@ -12,10 +12,9 @@ describe('Memlet with evictions', async () => {
 
     const disklet = makeMemoryDisklet()
     const memlet = makeMemlet(disklet, { maxMemoryUsage: fileASize })
+    const store = memlet._getStore()
 
     await memlet.setJson('File-A', fileA)
-
-    const store = memlet._getStore()
 
     // Check files
     expect(Object.keys(store.files)).deep.equals(['File-A'])
@@ -32,16 +31,169 @@ describe('Memlet with evictions', async () => {
     const memlet = makeMemlet(disklet, {
       maxMemoryUsage: fileBSize
     })
+    const store = memlet._getStore()
 
     await memlet.setJson('File-A', fileA)
     await delay(10)
     await memlet.setJson('File-B', fileB)
 
-    const store = memlet._getStore()
-
     // Check files
     expect(Object.keys(store.files)).deep.equals(['File-B'])
     // Check memoryUsage
     expect(store.memoryUsage).to.equal(fileBSize)
+  })
+
+  it('will remove multiple small files after a large file', async () => {
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some content' }
+    const fileC = { content: 'some content' }
+    const fileD = { content: 'some content' }
+    const fileE = { content: 'some content' }
+    const largeFile = {
+      content: `lots and lots and lots and lots and lots and lots and lots 
+      and lots and lots and lots and lots and lots and lots and lots and 
+      lots and lots of content`
+    }
+
+    const maxMemoryUsage =
+      JSON.stringify(largeFile).length + JSON.stringify(fileE).length * 2
+
+    const disklet = makeMemoryDisklet()
+    const memlet = makeMemlet(disklet, {
+      maxMemoryUsage
+    })
+    const store = memlet._getStore()
+
+    await memlet.setJson('File-A', fileA)
+    await delay(1)
+    await memlet.setJson('File-B', fileB)
+    await delay(1)
+    await memlet.setJson('File-C', fileC)
+    await delay(1)
+    await memlet.setJson('File-D', fileD)
+    await delay(1)
+    await memlet.setJson('File-E', fileE)
+    await delay(1)
+    await memlet.setJson('Large-File', largeFile)
+
+    expect(Object.keys(store.files)).deep.equals([
+      'File-D',
+      'File-E',
+      'Large-File'
+    ])
+  })
+
+  it('will evict file after reading a persisted file', async () => {
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some content' }
+
+    const maxMemoryUsage = JSON.stringify(fileA).length
+
+    const disklet = makeMemoryDisklet()
+
+    // Persisted file
+    await disklet.setText('File-A', JSON.stringify(fileA))
+
+    const memlet = makeMemlet(disklet, {
+      maxMemoryUsage
+    })
+    const store = memlet._getStore()
+
+    await memlet.setJson('File-B', fileB)
+    await delay(1)
+    await memlet.getJson('File-A')
+
+    expect(Object.keys(store.files)).deep.equals(['File-A'])
+  })
+
+  it('will evict multiple files after reading a large persisted file', async () => {
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some content' }
+    const fileC = { content: 'some content' }
+    const fileD = { content: 'some content' }
+    const fileE = { content: 'some content' }
+    const largeFile = {
+      content: `lots and lots and lots and lots and lots and lots and lots 
+      and lots and lots and lots and lots and lots and lots and lots and 
+      lots and lots of content`
+    }
+
+    const maxMemoryUsage =
+      JSON.stringify(largeFile).length + JSON.stringify(fileE).length * 2
+
+    const disklet = makeMemoryDisklet()
+
+    // Persisted file
+    await disklet.setText('Large-File', JSON.stringify(largeFile))
+
+    const memlet = makeMemlet(disklet, {
+      maxMemoryUsage
+    })
+    const store = memlet._getStore()
+
+    await memlet.setJson('File-A', fileA)
+    await delay(1)
+    await memlet.setJson('File-B', fileB)
+    await delay(1)
+    await memlet.setJson('File-C', fileC)
+    await delay(1)
+    await memlet.setJson('File-D', fileD)
+    await delay(1)
+    await memlet.setJson('File-E', fileE)
+    await delay(1)
+    await memlet.getJson('Large-File')
+
+    expect(Object.keys(store.files)).deep.equals([
+      'File-D',
+      'File-E',
+      'Large-File'
+    ])
+  })
+
+  it('will evict files after reading and writing files many times', async () => {
+    const fileData = { content: 'some content' }
+
+    const maxMemoryUsage = JSON.stringify(fileData).length * 3
+
+    const disklet = makeMemoryDisklet()
+
+    const memlet = makeMemlet(disklet, {
+      maxMemoryUsage
+    })
+    const store = memlet._getStore()
+
+    await memlet.setJson('File-A', fileData)
+
+    await memlet.setJson('File-B', fileData)
+
+    await memlet.setJson('File-C', fileData)
+
+    await memlet.setJson('File-D', fileData)
+
+    await memlet.setJson('File-E', fileData)
+
+    expect(Object.keys(store.files)).deep.equals(['File-C', 'File-D', 'File-E'])
+
+    await delay(10)
+
+    await memlet.getJson('File-B')
+
+    await memlet.getJson('File-A')
+
+    expect(Object.keys(store.files)).deep.equals(['File-E', 'File-B', 'File-A'])
+
+    await delay(10)
+
+    await memlet.setJson('File-F', fileData)
+
+    expect(Object.keys(store.files)).deep.equals(['File-B', 'File-A', 'File-F'])
+
+    await delay(10)
+
+    await memlet.getJson('File-C')
+    await memlet.getJson('File-D')
+    await memlet.getJson('File-E')
+
+    expect(Object.keys(store.files)).deep.equals(['File-C', 'File-D', 'File-E'])
   })
 })

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -3,12 +3,12 @@ import { makeMemoryDisklet } from 'disklet'
 import { describe, it } from 'mocha'
 
 import { makeMemlet } from '../src/index'
-import { delay } from './utils'
+import { delay, measureDataSize, measureMaxMemoryUsage } from './utils'
 
 describe('Memlet with evictions', async () => {
   it('can add files within maxMemoryUsage', async () => {
     const fileA = { content: 'some content' }
-    const fileASize = JSON.stringify(fileA).length
+    const fileASize = measureDataSize(fileA)
 
     const disklet = makeMemoryDisklet()
     const memlet = makeMemlet(disklet, { maxMemoryUsage: fileASize })
@@ -19,13 +19,13 @@ describe('Memlet with evictions', async () => {
     // Check files
     expect(Object.keys(store.files)).deep.equals(['File-A'])
     // Check memoryUsage
-    expect(store.memoryUsage).to.equal(fileASize)
+    expect(measureMaxMemoryUsage(store.memoryUsage)).to.equal(fileASize)
   })
 
   it('will remove old files when exceeding maxMemoryUsage', async () => {
     const fileA = { content: 'some content' }
     const fileB = { content: 'some other content' }
-    const fileBSize = JSON.stringify(fileB).length
+    const fileBSize = measureDataSize(fileB)
 
     const disklet = makeMemoryDisklet()
     const memlet = makeMemlet(disklet, {
@@ -40,7 +40,7 @@ describe('Memlet with evictions', async () => {
     // Check files
     expect(Object.keys(store.files)).deep.equals(['File-B'])
     // Check memoryUsage
-    expect(store.memoryUsage).to.equal(fileBSize)
+    expect(measureMaxMemoryUsage(store.memoryUsage)).to.equal(fileBSize)
   })
 
   it('will remove multiple small files after a large file', async () => {
@@ -56,7 +56,7 @@ describe('Memlet with evictions', async () => {
     }
 
     const maxMemoryUsage =
-      JSON.stringify(largeFile).length + JSON.stringify(fileE).length * 2
+      measureDataSize(largeFile) + measureDataSize(fileE) * 2
 
     const disklet = makeMemoryDisklet()
     const memlet = makeMemlet(disklet, {
@@ -87,7 +87,7 @@ describe('Memlet with evictions', async () => {
     const fileA = { content: 'some content' }
     const fileB = { content: 'some content' }
 
-    const maxMemoryUsage = JSON.stringify(fileA).length
+    const maxMemoryUsage = measureDataSize(fileA)
 
     const disklet = makeMemoryDisklet()
 
@@ -122,7 +122,7 @@ describe('Memlet with evictions', async () => {
     }
 
     const maxMemoryUsage =
-      JSON.stringify(largeFile).length + JSON.stringify(fileE).length * 2
+      measureDataSize(largeFile) + measureDataSize(fileE) * 2
 
     const disklet = makeMemoryDisklet()
 
@@ -156,7 +156,7 @@ describe('Memlet with evictions', async () => {
   it('will evict files after reading and writing files many times', async () => {
     const fileData = { content: 'some content' }
 
-    const maxMemoryUsage = JSON.stringify(fileData).length * 3
+    const maxMemoryUsage = measureDataSize(fileData) * 3
 
     const disklet = makeMemoryDisklet()
 

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha'
 import { makeMemlet, Memlet } from '../src/index'
 import { delay } from './utils'
 
-describe('memlet with evictions', async () => {
+describe('Memlet with evictions', async () => {
   it('can add files within maxMemoryUsage', async () => {
     const fileA = { content: 'some content' }
     const fileASize = JSON.stringify(fileA).length

--- a/test/eviction.test.ts
+++ b/test/eviction.test.ts
@@ -100,6 +100,9 @@ describe('Memlet with evictions', async () => {
     const store = memlet._getStore()
 
     await memlet.setJson('File-B', fileB)
+
+    expect(Object.keys(store.files)).deep.equals(['File-B'])
+
     await delay(1)
     await memlet.getJson('File-A')
 

--- a/test/file-queue.test.ts
+++ b/test/file-queue.test.ts
@@ -1,44 +1,182 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { makeFileQueue } from '../src/file-queue'
+import { FileQueue, makeFileQueue } from '../src/file-queue'
 import { File } from '../src'
-import { delay } from './utils'
+import { createFiles, delay } from './utils'
 
 describe('FileQueue', async () => {
-  const fileA: File = {
-    filename: 'file-A',
-    data: 'content',
-    size: 123,
-    lastTouchedTimestamp: Date.now()
-  }
-  const fileB: File = {
-    filename: 'file-B',
-    data: 'content',
-    size: 123,
-    lastTouchedTimestamp: Date.now() + 1
-  }
-  const fileC: File = {
-    filename: 'file-C',
-    data: 'content',
-    size: 123,
-    lastTouchedTimestamp: Date.now() + 2
-  }
+  it('can queue files: files in order', async () => {
+    const fileQueue = makeFileQueue()
 
-  it('can queue files', async () => {
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
+  })
+
+  it('can queue files: file timestamp greater than all files', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const fileD = {
+      ...fileC,
+      filename: 'D',
+      lastTouchedTimestamp: fileC.lastTouchedTimestamp + 1000
+    }
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+    fileQueue.queue(fileD)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC, fileD])
+  })
+
+  it('can queue files: file timestamp less than end', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const fileD = {
+      ...fileC,
+      filename: 'D',
+      lastTouchedTimestamp: fileC.lastTouchedTimestamp - 1
+    }
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+    fileQueue.queue(fileD)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileD, fileC])
+  })
+
+  it('can queue files: file timestamp equal to end', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const fileD = {
+      ...fileC,
+      filename: 'D',
+      lastTouchedTimestamp: fileC.lastTouchedTimestamp
+    }
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+    fileQueue.queue(fileD)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC, fileD])
+  })
+
+  it('can queue files: file timestamp lower than all files', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const fileD = {
+      ...fileC,
+      filename: 'D',
+      lastTouchedTimestamp: fileC.lastTouchedTimestamp - 1000
+    }
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+    fileQueue.queue(fileD)
+
+    expect(fileQueue.list()).deep.equals([fileD, fileA, fileB, fileC])
+  })
+
+  it('can queue files: lexicographically in order', async () => {
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
     const fileQueue = makeFileQueue()
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
     fileQueue.queue(fileC)
 
-    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
+  })
 
-    expect(filenames).deep.equals(['file-A', 'file-B', 'file-C'])
+  it('can queue files: lexicographically in reverse order', async () => {
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
+    const fileQueue = makeFileQueue()
+
+    fileQueue.queue(fileC)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileA)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
+  })
+
+  it('can queue files: lexicographically in random order', async () => {
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
+    const fileQueue = makeFileQueue()
+
+    ;[fileA, fileB, fileC]
+      .sort(() => Math.round(Math.random()))
+      .forEach(file => fileQueue.queue(file))
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
+  })
+
+  it('can queue files: File with same timestamp as a multiple files in the middle of the queue', async () => {
+    const firstFiles = createFiles(['X', 'Y', 'Z'])
+    await delay(10)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    await delay(10)
+    const lastFiles = createFiles(['abc', 'abc'])
+
+    let fileQueue: FileQueue
+
+    // Assertion will be the same for all checks
+    const assertion = (fileQueue: FileQueue) =>
+      expect(fileQueue.list().map(file => file.filename)).deep.equals([
+        ...firstFiles.map(file => file.filename),
+        fileA.filename,
+        fileB.filename,
+        fileC.filename,
+        ...lastFiles.map(file => file.filename)
+      ])
+
+    // Check with first of lexicographical order last
+    fileQueue = makeFileQueue()
+    firstFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+    lastFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileA)
+    assertion(fileQueue)
+
+    // Check with middle of lexicographical order last
+    fileQueue = makeFileQueue()
+    firstFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileC)
+    lastFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileB)
+    assertion(fileQueue)
+
+    // Check with last of lexicographical order last
+    fileQueue = makeFileQueue()
+    firstFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    lastFiles.forEach(file => fileQueue.queue(file))
+    fileQueue.queue(fileC)
+    assertion(fileQueue)
   })
 
   it('can dequeue files', async () => {
     const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -46,30 +184,101 @@ describe('FileQueue', async () => {
 
     const removedFile = fileQueue.dequeue()
 
-    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
-
-    expect(filenames).deep.equals(['file-B', 'file-C'])
-    expect(removedFile?.filename).equals('file-A')
+    expect(fileQueue.list()).deep.equals([fileB, fileC])
+    expect(removedFile).equals(fileA)
   })
 
-  it('can requeue files', async () => {
+  it('can requeue files at beginning', async () => {
     const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
     fileQueue.queue(fileC)
 
     await delay(10)
-
     fileQueue.requeue(fileA)
 
-    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
+    expect(fileQueue.list()).deep.equals([fileB, fileC, fileA])
+  })
 
-    expect(filenames).deep.equals(['file-B', 'file-C', 'file-A'])
+  it('can requeue files at middle', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    await delay(10)
+    fileQueue.requeue(fileB)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileC, fileB])
+  })
+
+  it('can requeue files at end', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    await delay(10)
+    fileQueue.requeue(fileC)
+
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
+  })
+
+  it('can requeue files at beginning (lexicographically)', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    await delay(10)
+    fileQueue.requeue(fileA)
+    expect(fileQueue.list()).deep.equals([fileB, fileC, fileA])
+  })
+
+  it('can requeue files at middle (lexicographically)', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    await delay(10)
+    fileQueue.requeue(fileB)
+    expect(fileQueue.list()).deep.equals([fileA, fileC, fileB])
+  })
+
+  it('can requeue files at end (lexicographically)', async () => {
+    const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+
+    fileQueue.queue(fileA)
+    fileQueue.queue(fileB)
+    fileQueue.queue(fileC)
+
+    await delay(10)
+    fileQueue.requeue(fileC)
+    expect(fileQueue.list()).deep.equals([fileA, fileB, fileC])
   })
 
   it('can remove files', async () => {
     const fileQueue = makeFileQueue()
+
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -77,8 +286,6 @@ describe('FileQueue', async () => {
 
     fileQueue.remove(fileB)
 
-    const filenames = fileQueue.list().map(fileEntry => fileEntry.filename)
-
-    expect(filenames).deep.equals(['file-A', 'file-C'])
+    expect(fileQueue.list()).deep.equals([fileA, fileC])
   })
 })

--- a/test/file-queue.test.ts
+++ b/test/file-queue.test.ts
@@ -9,7 +9,7 @@ describe('FileQueue', async () => {
   it('can queue files: files in order', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -21,7 +21,7 @@ describe('FileQueue', async () => {
   it('can queue files: file timestamp greater than all files', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
     const fileD = {
       ...fileC,
       filename: 'D',
@@ -39,7 +39,7 @@ describe('FileQueue', async () => {
   it('can queue files: file timestamp less than end', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
     const fileD = {
       ...fileC,
       filename: 'D',
@@ -57,7 +57,7 @@ describe('FileQueue', async () => {
   it('can queue files: file timestamp equal to end', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
     const fileD = {
       ...fileC,
       filename: 'D',
@@ -75,7 +75,7 @@ describe('FileQueue', async () => {
   it('can queue files: file timestamp lower than all files', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
     const fileD = {
       ...fileC,
       filename: 'D',
@@ -91,7 +91,7 @@ describe('FileQueue', async () => {
   })
 
   it('can queue files: lexicographically in order', async () => {
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     const fileQueue = makeFileQueue()
 
@@ -103,7 +103,7 @@ describe('FileQueue', async () => {
   })
 
   it('can queue files: lexicographically in reverse order', async () => {
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     const fileQueue = makeFileQueue()
 
@@ -115,7 +115,7 @@ describe('FileQueue', async () => {
   })
 
   it('can queue files: lexicographically in random order', async () => {
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     const fileQueue = makeFileQueue()
 
@@ -127,11 +127,11 @@ describe('FileQueue', async () => {
   })
 
   it('can queue files: File with same timestamp as a multiple files in the middle of the queue', async () => {
-    const firstFiles = createFiles(['X', 'Y', 'Z'])
+    const firstFiles = createFiles(['X', 'Y', 'Z'], 1)
     await delay(10)
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
     await delay(10)
-    const lastFiles = createFiles(['abc', 'abc'])
+    const lastFiles = createFiles(['abc', 'abc'], 1)
 
     let fileQueue: FileQueue
 
@@ -176,7 +176,7 @@ describe('FileQueue', async () => {
   it('can dequeue files', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -191,7 +191,7 @@ describe('FileQueue', async () => {
   it('can requeue files at beginning', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -206,7 +206,7 @@ describe('FileQueue', async () => {
   it('can requeue files at middle', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -221,7 +221,7 @@ describe('FileQueue', async () => {
   it('can requeue files at end', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -236,7 +236,7 @@ describe('FileQueue', async () => {
   it('can requeue files at beginning (lexicographically)', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -250,7 +250,7 @@ describe('FileQueue', async () => {
   it('can requeue files at middle (lexicographically)', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -264,7 +264,7 @@ describe('FileQueue', async () => {
   it('can requeue files at end (lexicographically)', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], true)
+    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'], 0)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
@@ -278,14 +278,27 @@ describe('FileQueue', async () => {
   it('can remove files', async () => {
     const fileQueue = makeFileQueue()
 
-    const [fileA, fileB, fileC] = createFiles(['A', 'B', 'C'])
+    const [fileA, fileB, fileC, fileD] = createFiles(['A', 'B', 'C', 'D'], 1)
 
     fileQueue.queue(fileA)
     fileQueue.queue(fileB)
     fileQueue.queue(fileC)
+    fileQueue.queue(fileD)
+
+    fileQueue.remove(fileA)
+
+    expect(fileQueue.list()).deep.equals([fileB, fileC, fileD])
+
+    fileQueue.remove(fileC)
+
+    expect(fileQueue.list()).deep.equals([fileB, fileD])
+
+    fileQueue.remove(fileD)
+
+    expect(fileQueue.list()).deep.equals([fileB])
 
     fileQueue.remove(fileB)
 
-    expect(fileQueue.list()).deep.equals([fileA, fileC])
+    expect(fileQueue.list()).deep.equals([])
   })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -16,3 +16,8 @@ export const createFiles = (filenames: string[], delay: number): File[] => {
     lastTouchedTimestamp: timestamp + index * delay
   }))
 }
+
+export const measureDataSize = (data: any) => JSON.stringify(data).length * 2
+
+export const measureMaxMemoryUsage = (maxMemoryUsage: number) =>
+  maxMemoryUsage * 2

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,16 +6,13 @@ export const delay = (ms: number) => {
   })
 }
 
-export const createFiles = (
-  filenames: string[],
-  sameTimestamps: boolean = false
-): File[] => {
+export const createFiles = (filenames: string[], delay: number): File[] => {
   const timestamp = Date.now()
 
   return filenames.map((filename, index) => ({
     filename,
     data: 'content',
     size: 123,
-    lastTouchedTimestamp: timestamp + (sameTimestamps ? 0 : index)
+    lastTouchedTimestamp: timestamp + index * delay
   }))
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,21 @@
+import { File } from '../src'
+
 export const delay = (ms: number) => {
   return new Promise(resolve => {
     setTimeout(resolve, ms)
   })
+}
+
+export const createFiles = (
+  filenames: string[],
+  sameTimestamps: boolean = false
+): File[] => {
+  const timestamp = Date.now()
+
+  return filenames.map((filename, index) => ({
+    filename,
+    data: 'content',
+    size: 123,
+    lastTouchedTimestamp: timestamp + (sameTimestamps ? 0 : index)
+  }))
 }


### PR DESCRIPTION
Includes change requests from previous meeting on 9/18/20. All unit tests implemented along with fixes to fully pass the test coverage.

**Checklist from meeting:**

- [x]  Typo on existingFile
- [x]  Use `out` over `this`
- [x]  Test Cases
    - [x]  `requeue`
        - [x]  `requeue` files at the beginning, middle and end (timestamp-wise and lexicographically)
    - [x]  `queue`
        - [x]  Timestamp checks:
            - [x]  File with a lower timestamp than file at end of queue
            - [x]  File with an equal timestamp to file at end of queue
            - [x]  File with a lower timestamp than all files in the queue
            - [x]  File with a higher timestamp than file at the end of queue (preferred use-case)
        - [x]  Lexicographical checks:
            - [x]  File with same timestamp as a multiple files in the middle of the queue
                - [x]  Check file's lexicographical order for these files at beginning, middle, and end
    - [x]  `Memlet`
        - [x]  Many small files and a large file should recursively remove small files until memoryUsage satisfies maxMemoryUsage
        - [x]  Reading persisted file ejects other file(s) from memory: Write fileA, read fileB (which is retrieved from disklet), and fileA gets evicted from memory because of memory usage would exceed maxMemoryUsage.
            - [x]  Variant: check with more than one file in memory.