### PR TITLE
Not Found Error Catching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,13 @@ const defaultConfig: MemletConfig = {
   maxMemoryUsage: Infinity
 }
 
+/**
+ * Regex to match error message for files not found errors.
+ * First, variation is from memory and localStorage memlet backends.
+ * Second variation is from iOS memlet backend.
+ */
+const notFoundErrorMessageRegex = /^Cannot load ".+"$|^Cannot read '.+'$/
+
 export function makeMemlet(
   disklet: Disklet,
   configOptions: Partial<MemletConfig> = {}
@@ -31,12 +38,18 @@ export function makeMemlet(
 
   // Private methods
 
-  const addStoreFile = (filename: string, data: any, size: number) => {
+  const addStoreFile = (
+    filename: string,
+    data: any,
+    size: number,
+    notFoundError?: any
+  ) => {
     const file: File = {
       filename,
       data,
       size,
-      lastTouchedTimestamp: Date.now()
+      lastTouchedTimestamp: Date.now(),
+      notFoundError
     }
 
     // Add file to file queue
@@ -117,16 +130,41 @@ export function makeMemlet(
         // Invoke adjustMemoryUsage to potentially evict files
         adjustMemoryUsage(0)
 
+        // If file contains a caught error, throw it.
+        if (file.notFoundError) {
+          throw file.notFoundError
+        }
+
         // Return file found in memory store
         return file.data
       } else {
-        // Retrieve file from disklet, store it, then return
-        const dataString = await disklet.getText(filename)
-        const data = JSON.parse(dataString)
+        try {
+          // Retrieve file from disklet, store it, then return
+          const dataString = await disklet.getText(filename)
+          const data = JSON.parse(dataString)
 
-        addStoreFile(filename, data, dataString.length)
+          addStoreFile(filename, data, dataString.length)
 
-        return data
+          return data
+        } catch (err) {
+          /**
+           * For file not found errors, store null data, include the error
+           * object, and then then re-throw. This saves needless disklet
+           * accesses on subsequent getJson invocations.
+           */
+          if (
+            err?.message.match(notFoundErrorMessageRegex) ||
+            err?.code === 'ENOENT'
+          ) {
+            const data = null
+            const dataString = JSON.stringify(data)
+
+            addStoreFile(filename, data, dataString.length, err)
+          }
+
+          // Re-throw the error from disklet
+          throw err
+        }
       }
     },
 
@@ -144,9 +182,13 @@ export function makeMemlet(
       if (file) {
         const previousSize = file.size
 
+        // Update all of file's fields
         file.lastTouchedTimestamp = Date.now()
         file.data = data
         file.size = JSON.stringify(data).length
+
+        // Remove error object if present
+        delete file.notFoundError
 
         // Update file's position in the file queue
         fileQueue.requeue(file)

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,10 +156,7 @@ export function makeMemlet(
             err?.message.match(notFoundErrorMessageRegex) ||
             err?.code === 'ENOENT'
           ) {
-            const data = null
-            const dataString = JSON.stringify(data)
-
-            addStoreFile(filename, data, dataString.length, err)
+            addStoreFile(filename, null, 0, err)
           }
 
           // Re-throw the error from disklet

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,5 +29,5 @@ export interface File {
   size: number
   data: any
   lastTouchedTimestamp: number
+  notFoundError?: any
 }
-


### PR DESCRIPTION
This update is for performance improvements for `getJson` method involving missing file errors. Memlet will cache a null object in place of a missing file along with the error object and re-throw the error object on subsequent `getJson` invocations until a file is written using `setJson`.