### PR TITLE
Refactored memlet to use shared state for all instances from makeMemlet

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
+    "@types/chai-as-promised": "^7.1.3",
+    "chai-as-promised": "^7.1.1",
     "disklet": "^0.4.5"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { DiskletListing } from 'disklet'
+import { FileQueue } from './file-queue'
 
 export interface Memlet {
   list: (path?: string) => Promise<DiskletListing>
@@ -7,8 +8,12 @@ export interface Memlet {
 
   getJson: (path: string) => Promise<any>
   setJson: (path: string, obj: any) => Promise<void>
+}
 
-  _getStore: () => MemletStore
+export interface MemletState {
+  config: MemletConfig
+  store: MemletStore
+  fileQueue: FileQueue
 }
 
 export interface MemletStore {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -2,7 +2,7 @@ import { assert, expect } from 'chai'
 import { makeMemoryDisklet, makeNodeDisklet } from 'disklet'
 import { describe, it } from 'mocha'
 
-import { makeMemlet, Memlet } from '../src/index'
+import { makeMemlet, Memlet, _getMemletState } from '../src/index'
 
 export async function createObjects(memlet: Memlet) {
   const fileA = { content: 'file content' }
@@ -69,14 +69,14 @@ describe('Memlet', async () => {
   })
 
   it('memory usage is correct', async () => {
-    const store = memlet._getStore()
+    const state = _getMemletState()
 
-    const sumOfFileSizes = Object.values(store.files).reduce(
+    const sumOfFileSizes = Object.values(state.store.files).reduce(
       (sum, file) => sum + file.size,
       0
     )
 
-    expect(store.memoryUsage).to.equal(sumOfFileSizes)
+    expect(state.store.memoryUsage).to.equal(sumOfFileSizes)
   })
 
   it('will cache on file not found error (memory backend)', async () => {

--- a/test/shared-state.test.ts
+++ b/test/shared-state.test.ts
@@ -1,0 +1,74 @@
+import { expect, use } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { makeMemoryDisklet } from 'disklet'
+import { describe, it } from 'mocha'
+
+use(chaiAsPromised)
+
+import {
+  _getMemletState,
+  makeMemlet,
+  setMemletConfig,
+  resetMemletState
+} from '../src/index'
+import {
+  delay,
+  getNormalizeStoreFilenames,
+  measureDataSize,
+  measureMaxMemoryUsage
+} from './utils'
+
+describe('Memlets with shared state', async () => {
+  beforeEach('reset memlet state', () => {
+    resetMemletState()
+  })
+
+  const state = _getMemletState()
+
+  it('will evict files when exceeding shared maxMemoryUsage', async () => {
+    const diskletA = makeMemoryDisklet()
+    const diskletB = makeMemoryDisklet()
+    const memletA = makeMemlet(diskletA)
+    const memletB = makeMemlet(diskletB)
+
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some other content' }
+    const fileBSize = measureDataSize(fileB)
+
+    setMemletConfig({ maxMemoryUsage: fileBSize })
+
+    await memletA.setJson('File-A', fileA)
+    await delay(10)
+    await memletB.setJson('File-B', fileB)
+
+    // Check memoryUsage
+    expect(measureMaxMemoryUsage(state.store.memoryUsage)).to.equal(fileBSize)
+    // Check files
+    expect(getNormalizeStoreFilenames(state)).deep.equals(['File-B'])
+  })
+
+  it('will not share file paths', async () => {
+    const diskletA = makeMemoryDisklet()
+    const diskletB = makeMemoryDisklet()
+    const memletA = makeMemlet(diskletA)
+    const memletB = makeMemlet(diskletB)
+
+    const fileA = { content: 'some content' }
+    const fileB = { content: 'some other content' }
+
+    await memletA.setJson('File-A', fileA)
+    await delay(10)
+    await memletB.setJson('File-B', fileB)
+    await delay(1)
+
+    expect(getNormalizeStoreFilenames(state)).deep.equals(['File-A', 'File-B'])
+
+    // Can access files
+    await memletA.getJson('File-A')
+    await memletB.getJson('File-B')
+
+    // Cannot access files
+    expect(memletA.getJson('File-B')).to.be.rejectedWith('Cannot load "File-B"')
+    expect(memletB.getJson('File-A')).to.be.rejectedWith('Cannot load "File-A"')
+  })
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import { File } from '../src'
+import { File, MemletState } from '../src'
 
 export const delay = (ms: number) => {
   return new Promise(resolve => {
@@ -21,3 +21,8 @@ export const measureDataSize = (data: any) => JSON.stringify(data).length * 2
 
 export const measureMaxMemoryUsage = (maxMemoryUsage: number) =>
   maxMemoryUsage * 2
+
+export const getNormalizeStoreFilenames = (state: MemletState) => {
+  const filenames = Object.keys(state.store.files)
+  return filenames.map(filename => filename.replace(/^\d+:/, ''))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,18 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/chai-as-promised@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz#779166b90fda611963a3adbfd00b339d03b747bd"
+  integrity sha512-FQnh1ohPXJELpKhzjuDkPLR2BZCAqed+a6xV4MI/T3XzHfd2FlarfUGUdZYgqYe8oxkYn0fchHEeHfHqdZ96sg==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
+  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+
 "@types/chai@^4.2.12":
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.12.tgz#6160ae454cd89dae05adc3bb97997f488b608201"
@@ -1282,6 +1294,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
 
 chai@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
* All memlet instances will use the same config, store, and fileQueue
* Replaced makeMemlet configOptions parameter with setMemletConfig
exported module method
* Replaced memlet._getStore with _getMemletState exported module method
* Added clearMemletCache and resetMemletState module methods
* Added basic unit tests for shared state between multiple memlet
instances